### PR TITLE
fix coordinate transformation for objects with (exactly) 25 chars height

### DIFF
--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -258,6 +258,11 @@ void sh_deskf(WORD obj, LONG plong)
     OBJECT *tree;
 
     tree = rs_trees[DESKTOP];
+
+    /*
+     * set height of root DESKTOP object to screen height
+     */
+    tree[0].ob_height = gl_rscreen.g_h;
     *(LONG *)plong = tree[obj].ob_spec;
 }
 

--- a/aes/gemrslib.c
+++ b/aes/gemrslib.c
@@ -104,8 +104,7 @@ static char    free_str[256];   /* must be long enough for longest freestring in
 
 /*
  *  Fix up a character position, from offset,row/col to a pixel value.
- *  If width is 80 then convert to full screen width.  If height is 25
- *  then convert to full screen height.  Is this correct??
+ *  If width is 80 then convert to full screen width.
  */
 static void fix_chpos(WORD *pfix, WORD offset)
 {
@@ -131,10 +130,7 @@ static void fix_chpos(WORD *pfix, WORD offset)
             cpos *= gl_wchar;
         break;
     case 3:
-        if (cpos == 25)
-            cpos = gl_height;
-        else
-            cpos *= gl_hchar;
+        cpos *= gl_hchar;
         break;
     }
 

--- a/desk/desksupp.c
+++ b/desk/desksupp.c
@@ -239,6 +239,13 @@ void do_wopen(WORD new_win, WORD wh, WORD curr, WORD x, WORD y, WORD w, WORD h)
     {
         get_xywh(G.g_screen, G.g_croot, &c.g_x, &c.g_y, &c.g_w, &c.g_h);
         get_xywh(G.g_screen, curr, &d.g_x, &d.g_y, &d.g_w, &d.g_h);
+
+        if (!new_win)   /* no new window: window-relative coordinates */
+        {
+            d.g_x += x; /* window to screen coordinates */
+            d.g_y += y;
+        }
+
         graf_growbox(d.g_x, d.g_y, d.g_w, d.g_h, x, y, w, h);
         act_chg(G.g_cwin, G.g_screen, G.g_croot, curr, &c, SELECTED, FALSE, TRUE, TRUE);
     }


### PR DESCRIPTION
`rs_obfix()` was (wrongly) "fixing" object heights to screen height if they equalled to exactly 25 x screen font character height. This pull request fixes Kronos display in high resolution.

![grab0001](https://cloud.githubusercontent.com/assets/18102882/24584680/89895680-1775-11e7-821f-accb84a27bc3.png)
