### PR TITLE
obfuscate NULL dereference to avoid compiler over-optimization

### DIFF
--- a/bios/bios.c
+++ b/bios/bios.c
@@ -118,7 +118,14 @@ static void vecs_init(void)
      * To mimic Atari hardware behaviour, we copy the start of our OS there.
      * This may improve compatibility with some Atari software,
      * which may peek the OS version or reset address from there. */
-    ULONG_AT(0x00000000) = ((ULONG*)&os_header)[0]; /* Reset: Initial SSP */
+    {
+        /* Dereferencing zero is undefined behaviour, so we have to hide what
+         * we're doing here from the compiler, as otherwise it will assume
+         * this code will never be executed and delete it all.
+         */
+        ULONG * volatile zero_ptr = &ULONG_AT(0x00000000);
+        *zero_ptr = ((ULONG*)&os_header)[0];
+    }
     ULONG_AT(0x00000004) = ((ULONG*)&os_header)[1]; /* Reset: Initial PC */
 #endif
 


### PR DESCRIPTION
gcc 8.3.0 (and probably earlier versions as well) aggressively prune code paths containing undefined behaviour (and leave 'trap #7' instructions behind to tell you what they've done).

See https://blog.regehr.org/archives/213

The alternative would be to build with -ffreestanding, as the rules are a little different there, but that brings in more potential side-effects and I don't have a way to test changes at that scale...