### PR TITLE
If we cd on another drive, change to that drive temporarily so the Ds…

### DIFF
--- a/cli/cmdint.c
+++ b/cli/cmdint.c
@@ -210,10 +210,24 @@ PRIVATE LONG run_cd(WORD argc,char **argv)
 {
 char path[MAXPATHLEN];
 LONG rc;
+char *p;
+    p = argv[1];
 
-    if (argc != 1)
-        return Dsetpath(argv[1]);
+    if (argc != 1) {
+        /* If the path specifies a drive, we need to temporarily change to that drive. We do that unconditionnally to
+         * save a bit of memory, and also to validate that the drive is still valid. */
+        if (strlen(p) >= 2 && p[1] == ':') {
+            char current_drive = Dgetdrv();
+            if ((rc = run_setdrv(1,&p))) return rc;
+            if ((rc = Dsetpath(p))) return rc;
+            Dsetdrv(current_drive);
+            return rc;
+		}
+        else
+            return Dsetpath(p);
+    }
 
+    /* Just output current path */
     rc = get_path(path);
     outputnl(path);
 

--- a/cli/cmdint.c
+++ b/cli/cmdint.c
@@ -214,20 +214,21 @@ char *p;
     p = argv[1];
 
     if (argc != 1) {
-        /* If the path specifies a drive, we need to temporarily change to that drive. We do that unconditionnally to
-         * save a bit of memory, and also to validate that the drive is still valid. */
+        /* if the path specifies a drive, we need to temporarily change to
+         * that drive. We do that unconditionnally to save a bit of memory,
+         * and also to validate that the drive is still valid */
         if (strlen(p) >= 2 && p[1] == ':') {
-            char current_drive = Dgetdrv();
+            WORD current_drive = Dgetdrv();
             if ((rc = run_setdrv(1,&p))) return rc;
-            if ((rc = Dsetpath(p))) return rc;
+            rc = Dsetpath(p);
             Dsetdrv(current_drive);
             return rc;
-		}
+        }
         else
             return Dsetpath(p);
     }
 
-    /* Just output current path */
+    /* just output current path */
     rc = get_path(path);
     outputnl(path);
 


### PR DESCRIPTION
(my first pull request on github and contribution to emutos, yay)

Issue:
C:\>cd d:\somedir
C:\somedir      <- wrong ! we cd'd on D:

Fix:
When we "cd", if we provide an argument that starts with x: (x being a valid drive) then we want to Dsetdrv to that drive, do the Dsetpath then restore the previous drive.
