### PR TITLE
Improve layering by reducing dependencies from BIOS to BDOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ bios_src += lowstram.c
 # Other BIOS sources can be put in any order
 bios_src +=  memory.S processor.S vectors.S aciavecs.S bios.c xbios.c acsi.c \
              biosmem.c blkdev.c chardev.c clock.c conout.c country.c \
-             disk.c dma.c dmasound.c floppy.c font.c ide.c ikbd.c initinfo.c \
+             disk.c dma.c dmasound.c floppy.c font.c ide.c ikbd.c \
              kprint.c kprintasm.S linea.S lineainit.c lineavars.S machine.c \
              mfp.c midi.c mouse.c natfeat.S natfeats.c nvram.c panicasm.S \
              parport.c screen.c serport.c sound.c videl.c vt52.c xhdi.c \
@@ -289,7 +289,7 @@ endif
 
 bdos_src = bdosmain.c console.c fsbuf.c fsdir.c fsdrive.c fsfat.c fsglob.c \
            fshand.c fsio.c fsmain.c fsopnclo.c iumem.c kpgmld.c osmem.c \
-           proc.c rwa.S time.c umem.c
+           proc.c rwa.S time.c umem.c initinfo.c bootstrap.c
 
 #
 # source code in util/

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -29,6 +29,7 @@
 #include "mforms.h"
 #include "xbiosbind.h"
 #include "has.h"
+#include "../bdos/bdosstub.h"
 #include "biosext.h"
 
 #include "gemgsxif.h"

--- a/bdos/bdosstub.h
+++ b/bdos/bdosstub.h
@@ -12,31 +12,28 @@
 
 #include "bdosdefs.h"
 
-/* BDOS initialization, called after BIOS initialization.
- * This is done in 2 parts: before and after Alt-RAM is available */
-void osinit_before_xmaddalt(void);
-void osinit_after_xmaddalt(void);
+/* Boot flags.
+ * TODO: this should be private to the BDOS
+ */
+extern UBYTE bootflags;
+#define BOOTFLAG_EARLY_CLI     0x01
+#define BOOTFLAG_SKIP_HDD_BOOT 0x02
+#define BOOTFLAG_SKIP_AUTO_ACC 0x04
 
-#if CONF_WITH_ALT_RAM
-/* Register an Alt-RAM region to BDOS */
-long xmaddalt(UBYTE *start, long size);
-
-/* Get the total size of Alt-RAM regions */
-long total_alt_ram(void);
-#endif /* CONF_WITH_ALT_RAM */
-
-/* BDOS quick pool.
- * Declared here because referenced by the BIOS OSHEADER */
-#define MAXQUICK 5
-extern WORD *root[MAXQUICK];
+/* Start the BDOS */
+void bdos_bootstrap(void);
 
 /* Pointer to the basepage of the current process.
  * Declared here because referenced by the BIOS OSHEADER,
- * and also by bios/kprint.c */
+ * and also by bios/kprint.c
+ * TODO: this is dirty as it allwows the BIOS to access data from an upper layer
+ */
 extern PD *run;
 
 /* BDOS current date/time.
- * Declared here because also updated by XBIOS Settime() */
+ * Declared here because also updated by XBIOS Settime()
+ * TODO: this is dirty as it allwows the BIOS to access data from an upper layer
+ */
 extern UWORD current_date, current_time;
 
 #endif /* _BDOSSTUB_H */

--- a/bdos/bootstrap.c
+++ b/bdos/bootstrap.c
@@ -1,0 +1,333 @@
+/*
+ * bootstrap.c - Startup the GEMDOS
+ *
+ * Copyright (C) 2001 Lineo, Inc.
+ *               2002-2021 The EmuTOS development team
+ *
+ * Authors:
+ *  EWF  Eric W. Fleischman
+ *  JSL  Jason S. Loveman
+ *  SCC  Steven C. Cavender
+ *  LTG  Louis T. Garavaglia
+ *  KTB  Karl T. Braun (kral)
+ *  ACH  Anthony C. Hay (DR UK)
+ *  MAD  Martin Doering
+ *  THH  Thomas Huth
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "emutos.h"
+#include "fs.h"
+#include "mem.h"
+#include "console.h"
+#include "time.h"
+#include "string.h"
+#include "bdosstub.h"
+#include "biosbind.h"   /* for Kbshift() */
+#include "biosext.h"
+#include "bdosbind.h"   /* it's ok to use the BDOS from the bootstraper */
+#include "initinfo.h"
+#if WITH_CLI
+#include "../cli/clistub.h"
+#endif
+
+
+#define ENABLE_RESET_RESIDENT 0 /* enable to run "reset-resident" code (see below) */
+
+/* Gloval variable */
+UBYTE bootflags;
+
+/* Environment stuff */
+#define ENV_SIZE    12              /* sufficient for standard PATH=^X:\^^ (^=nul byte) */
+#define DEF_PATH    "A:\\"          /* default value for path */
+static char default_env[ENV_SIZE];  /* default environment area */
+
+/* Initial process setup */
+static const char double_nul[2] __attribute__ ((aligned (2))) = { 0, 0 }; /* env string for initial process */
+static PD initial_basepage;     /* basepage of initial process (statically allocated since never freed) */
+
+static void install(void);
+static void startup(void);
+static void init_default_environment(void);
+static void init_memory(void);
+static void autoexec(void);
+static LONG apply_boot_settings(ULONG shiftbits);
+
+void bdos_install_traps(void); /* in bdosmain.c */
+
+/*
+ * Setup the GEMDOS then execute the os (_exec_os).
+ */
+void bdos_bootstrap(void)
+{
+    install();
+    startup();
+}
+
+/*
+ * Install the BDOS (a.k.a GEMDOS)
+ */
+static void install(void)
+{
+    bdos_install_traps();
+
+    /* Setup memory and management of it */
+    bufl_init();
+    init_memory();
+
+    /* Set up initial process. Required by Malloc() */
+    run = &initial_basepage;
+    run->p_flags = PF_STANDARD;
+    run->p_env = CONST_CAST(char *,double_nul);
+    KDEBUG(("BDOS: address of basepage = %p\n", run));
+
+    time_init();
+
+    stdhdl_init();  /* set up system initial standard handles */
+
+    KDEBUG(("BDOS: install successful ...\n"));
+}
+
+/*
+ * Register memory detected by the BIOS to the BDOS pool
+ */
+static void init_memory(void)
+{
+    /* Init memory */
+    osmem_init();
+    umem_init();
+
+/* We can have this conditional check to save a few bytes as effectively 
+ * we only take action on blocks of type ALT */
+#if CONF_WITH_ALT_RAM 
+    {
+        struct memory_block_t *mem;
+    
+        for (mem = bget_memory_info(); mem != NULL; mem = mem->next)
+        {
+            if (mem->type == ALT)
+                xmaddalt((UBYTE*)mem->start, mem->size);
+        }
+    }
+#endif
+}
+
+/*
+ * Collect user boot settings and act accordingly by starting processes.
+ */
+static void startup(void)
+{
+    BOOL  show_initinfo;         /* TRUE if welcome screen must be displayed */
+    ULONG shiftbits;
+    BOOL  first_boot;
+
+    KDEBUG(("drvbits = %08lx\n",drvbits));
+
+    /* Steem needs this to initialize its GEMDOS hard disk emulation.
+     * This may change drvbits. See Steem sources:
+     * File steem/code/emulator.cpp, function intercept_bios(). */
+    Drvmap();
+
+    /* If it's not the first boot, we use the existing bootdev.
+     * this allows a boot device that was selected via the welcome
+     * screen to persist across warm boots. */
+    first_boot = is_first_boot();
+    if (first_boot)
+        bootdev = is_drive_available(DEFAULT_BOOTDEV) ? DEFAULT_BOOTDEV : FLOPPY_BOOTDEV;
+
+    /* Get boot preferences */
+#if INITINFO_DURATION == 0
+    show_initinfo = FALSE;
+#elif ALWAYS_SHOW_INITINFO
+    show_initinfo = TRUE;
+#else
+    show_initinfo = first_boot;
+#endif
+    if (show_initinfo)
+        bootdev = initinfo(&shiftbits); /* Show the welcome screen */
+    else
+        shiftbits = Kbshift(-1);
+
+    /* Update bootdev/bootflags according to what's possible and user choices */
+    apply_boot_settings(shiftbits);
+
+    KDEBUG(("bootdev = %d\n", bootdev));
+    KDEBUG(("bootflags = 0x%02x\n", bootflags));
+
+    /* Execute the bootsector code (if present) */
+    (*hdv_boot)();
+
+    Dsetdrv(bootdev);           /* Set boot drive as current */
+
+    init_default_environment(); /* Build default environment string */
+
+#if ENABLE_RESET_RESIDENT
+    run_reset_resident();
+#endif
+
+#if WITH_CLI
+    if (bootflags & BOOTFLAG_EARLY_CLI) {
+        /* Run an early console, passing the default environment */
+        PD *pd = (PD *) Pexec(PE_BASEPAGEFLAGS, (char *)PF_STANDARD, "", default_env);
+        pd->p_tbase = (UBYTE *) coma_start;
+        pd->p_tlen = pd->p_dlen = pd->p_blen = 0;
+        Pexec(PE_GOTHENFREE, "", (char *)pd, default_env);
+    }
+#endif
+
+    /* Run programs from the AUTO folder */
+    autoexec();
+
+    /* Give control to next process to run */
+    if (cmdload != 0) {
+        /* Run COMMAND.PRG with an empty environment (like Atari TOS) */
+        Pexec(PE_LOADGO, "COMMAND.PRG", "", NULL);
+    } else if (exec_os) {
+        /* Start the default (ROM) shell with the default environment (like Atari TOS) */
+        PD *pd;
+        pd = (PD *) Pexec(PE_BASEPAGEFLAGS, (char *)PF_STANDARD, "", default_env);
+        pd->p_tbase = (UBYTE *) exec_os;
+        pd->p_tlen = pd->p_dlen = pd->p_blen = 0;
+        Pexec(PE_GO, "", (char *)pd, default_env);
+    }
+}
+
+
+/*
+ * Build the default environment string: "PATH=^X:\^^" [where ^=nul]
+ */
+static void init_default_environment(void)
+{
+    char *p;
+
+    strcpy(default_env,PATH_ENV);
+    p = default_env + sizeof(PATH_ENV); /* point to first byte of path string */
+    strcpy(p,DEF_PATH);
+    *p += bootdev;                      /* fix up drive letter */
+    p += sizeof(DEF_PATH);
+    *p = '\0';                          /* terminate with double nul */
+}
+
+/*
+ * boot_from_block_device - boot from device in 'bootdev'
+ */
+static LONG apply_boot_settings(ULONG shiftbits)
+{
+    if (shiftbits & MODE_ALT)
+        bootflags |= BOOTFLAG_SKIP_HDD_BOOT;
+
+    if (shiftbits & MODE_CTRL)
+        bootflags |= BOOTFLAG_SKIP_AUTO_ACC;
+
+    /* If the user decided to skip hard drive boot, we set the boot device to floppy A: */
+    if (bootflags & BOOTFLAG_SKIP_HDD_BOOT)
+        bootdev = FLOPPY_BOOTDEV;
+
+    /*If the user decided to skip AUTO programs, we don't attempt to execute the bootsector */
+    if (bootflags & BOOTFLAG_SKIP_AUTO_ACC)
+        return 0;
+
+#ifdef DISABLE_HD_BOOT
+    if (bootdev >= NUMFLOPPIES) /* don't attempt to boot from hard disk */
+        return 0;
+#endif
+}
+
+/*
+ * autoexec - run programs in auto folder
+ *
+ * Skip this if user holds the Control key down.
+ *
+ * Note that GEMDOS already created a default basepage so it is safe
+ * to use GEMDOS calls here!
+ */
+
+static void run_auto_program(const char* filename)
+{
+    char path[30];
+
+    strcpy(path, "\\AUTO\\");
+    strcat(path, filename);
+
+    KDEBUG(("Loading %s ...\n", path));
+    Pexec(PE_LOADGO, path, "", NULL);
+    KDEBUG(("[OK]\n"));
+}
+
+static void autoexec(void)
+{
+    DTA dta;
+    WORD err;
+
+    /* check if the user does not want to run AUTO programs */
+    if (bootflags & BOOTFLAG_SKIP_AUTO_ACC)
+        return;
+
+#if DETECT_NATIVE_FEATURES
+    natfeat_bootstrap(default_env);           /* try to boot the new OS kernel directly */
+#endif
+
+    if(!is_drive_available(bootdev))          /* check, if bootdev available */
+        return;
+
+    Fsetdta(&dta);
+    err = Fsfirst("\\AUTO\\*.PRG", 7);
+    while(err == 0) {
+#ifdef TARGET_PRG
+        if (!strncmp(dta.d_fname, "EMUTOS", 6))
+        {
+            KDEBUG(("Skipping %s from AUTO folder\n", dta.d_fname));
+        }
+        else
+#endif
+        {
+            run_auto_program(dta.d_fname);
+
+            /* Setdta. BetaDOS corrupted the AUTO load if the Setdta
+             * not repeated here */
+            Fsetdta(&dta);
+        }
+
+        err = Fsnext();
+    }
+}
+
+#if ENABLE_RESET_RESIDENT
+/*
+ * run_reset_resident - run "reset-resident" code
+ *
+ * "Reset-resident" code is code that has been loaded into RAM prior
+ * to a warm boot.  It has a special header with a magic number, it
+ * is 512 bytes long (aligned on a 512-byte boundary), and it has a
+ * specific checksum (calculated on a word basis).
+ *
+ * Note: this is an undocumented feature of TOS that exists in all
+ * versions of Atari TOS.
+ */
+struct rrcode {
+    long magic;
+    struct rrcode *pointer;
+    char program[502];
+    short chksumfix;
+};
+#define RR_MAGIC    0x12123456L
+#define RR_CHKSUM   0x5678
+
+static void run_reset_resident(void)
+{
+    const struct rrcode *p = (const struct rrcode *)phystop;
+
+    for (--p; p > (struct rrcode *)&etv_timer; p--)
+    {
+        if (p->magic != RR_MAGIC)
+            continue;
+        if (p->pointer != p)
+            continue;
+        if (compute_cksum((const UWORD *)p) != RR_CHKSUM)
+            continue;
+        regsafe_call(p->program);
+    }
+}
+#endif

--- a/bdos/fs.h
+++ b/bdos/fs.h
@@ -23,7 +23,7 @@
 
 #include "biosdefs.h"
 #include "bdosdefs.h"
-
+#include "tosvars.h" /* for drvbits */
 
 /*
  *  constants
@@ -31,6 +31,13 @@
 
 #define SLASH '\\'
 #define FNAMELEN    (LEN_ZNODE+LEN_ZEXT)    /* as found in dirs etc */
+
+/*
+ * drive numbers used during startup
+ */
+#define FLOPPY_BOOTDEV      0   /* i.e. A: */
+#define HARDDISK_BOOTDEV    2   /* i.e. C: */
+#define DEFAULT_BOOTDEV     HARDDISK_BOOTDEV
 
 /*
  * the following values are used by Atari TOS:
@@ -350,6 +357,8 @@ long ckdrv(int d, BOOL checkrem);
 
 /* log in media 'b' on drive 'drv'. */
 long log_media(BPB *b, int drv);
+
+LONG is_drive_available(WORD dev);
 
 /*
  * in fshand.c

--- a/bdos/fsdrive.c
+++ b/bdos/fsdrive.c
@@ -240,3 +240,14 @@ long log_media(BPB *b, int drv)
 
     return E_OK;
 }
+
+/*
+ * is_drive_available - Check drive availability
+ *
+ * Returns 0, if drive not available
+ */
+
+LONG is_drive_available(WORD dev)
+{
+    return((1L << dev) & drvbits);
+}

--- a/bdos/initinfo.h
+++ b/bdos/initinfo.h
@@ -18,6 +18,5 @@
 /*==== Prototypes =========================================================*/
 
 WORD initinfo(ULONG *pshiftbits);
-void display_startup_msg(void);
 
 #endif /* INITINFO_H */

--- a/bdos/mem.h
+++ b/bdos/mem.h
@@ -69,6 +69,14 @@ long xsetblk(int n, void *blk, long len);
 /* mxalloc */
 void *xmxalloc(long amount, int mode);
 
+#if CONF_WITH_ALT_RAM
+/* Register an Alt-RAM region */
+long xmaddalt(UBYTE *start, long size);
+
+/* Get the total size of Alt-RAM regions */
+long total_alt_ram(void);
+#endif /* CONF_WITH_ALT_RAM */
+
 #if CONF_WITH_VIDEL
 /* srealloc */
 void *srealloc(long amount);

--- a/bdos/osmem.c
+++ b/bdos/osmem.c
@@ -37,7 +37,7 @@
 #define LEN_OSM_BLOCK   (2+64)      /* in bytes */
 /* size of os memory pool, in words: */
 #define LENOSM          (LEN_OSM_BLOCK*NUM_OSM_BLOCKS/sizeof(WORD))
-
+#define MAXQUICK 5
 
 /*
  *  local typedefs

--- a/bdos/proc.c
+++ b/bdos/proc.c
@@ -190,7 +190,7 @@ long xexec(WORD flag, char *path, char *tail, char *env)
     /* first branch - actions that do not require loading files */
     switch(flag) {
 #if DETECT_NATIVE_FEATURES
-    case PE_RELOCATE:   /* internal use only, see bootstrap() in bios/bios.c */
+    case PE_RELOCATE:   /* internal use only, see natfeat_bootstrap() in bdos/bootstrap.c */
         p = (PD *) tail;
         rc = kpgm_relocate(p, (long)path);
         if (rc) {

--- a/bios/amiga.c
+++ b/bios/amiga.c
@@ -404,8 +404,7 @@ static void add_slow_ram(void)
     if (size == 0)
         return;
 
-    KDEBUG(("Slow RAM detected at %p, size=%lu\n", start, size));
-    xmaddalt(start, size);
+    bmem_register("Slow", ALT, start, size);
 }
 
 /* Detect A3000/A4000 Processor Slot Fast RAM, a.k.a. Ramsey High MBRAM.
@@ -423,8 +422,7 @@ static void add_processor_slot_fast_ram(void)
     if (size == 0)
         return;
 
-    KDEBUG(("Processor Slot Fast RAM detected at %p, size=%lu\n", start, size));
-    xmaddalt(start, size);
+    bmem_register("Processor Slot Fast", ALT, (void*)start, size);
 }
 
 /* Detect A3000/A4000 Motherboard Fast RAM, a.k.a. Ramsey Low MBRAM.
@@ -443,8 +441,7 @@ static void add_motherboard_fast_ram(void)
     if (size == 0)
         return;
 
-    KDEBUG(("Motherboard Fast RAM detected at %p, size=%lu\n", end - size, size));
-    xmaddalt(end - size, size);
+    bmem_register("Motherboard Fast", ALT, (void *)end - size, size);
 }
 
 /* Forward declarations */
@@ -479,8 +476,7 @@ static void add_alt_ram_from_loader(void)
     {
         UBYTE *address = altram_regions[i].address;
         ULONG size = altram_regions[i].size;
-        KDEBUG(("xmaddalt(%p, %lu)\n", address, size));
-        xmaddalt(address, size);
+        bmem_register("ALT", ALT, (void *)address, size);
     }
 }
 
@@ -1370,8 +1366,7 @@ static void add_uae_32bit_chip_ram(void)
 
     uae_getchipmemsize(&z3chipmem_start, &z3chipmem_size);
 
-    KDEBUG(("UAE 32-bit Chip RAM detected at %p, size=%lu\n", z3chipmem_start, z3chipmem_size));
-    xmaddalt(z3chipmem_start, z3chipmem_size);
+    bmem_register("UAE 32-bit Chip", ALT, (void *)z3chipmem_start, z3chipmem_size);
 }
 
 /******************************************************************************/
@@ -2927,7 +2922,7 @@ static void add_ram_from_board(struct ConfigDev *configDev)
         configDev, configDev->cd_BoardAddr, configDev->cd_BoardSize));
 
     /* Register this Alt-RAM to the OS */
-    xmaddalt(configDev->cd_BoardAddr, configDev->cd_BoardSize);
+    bmem_register("Expansion", ALT, configDev->cd_BoardAddr, configDev->cd_BoardSize);
 
     /* This board has been processed */
     configDev->cd_Flags |= CDF_PROCESSED;

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -29,7 +29,6 @@
 #include "lineavars.h"
 #include "vt52.h"
 #include "processor.h"
-#include "initinfo.h"
 #include "machine.h"
 #include "has.h"
 #include "cookie.h"
@@ -59,24 +58,14 @@
 #include "memory.h"
 #include "nova.h"
 #include "tosvars.h"
+#include "version.h"
 #include "amiga.h"
 #include "lisa.h"
 #include "coldfire.h"
-#if WITH_CLI
-#include "../cli/clistub.h"
-#endif
-
-
 
 /*==== Defines ============================================================*/
 
 #define DBGBIOS 0               /* If you want to enable debug wrappers */
-#define ENABLE_RESET_RESIDENT 0 /* enable to run "reset-resident" code (see below) */
-
-#define ENV_SIZE    12          /* sufficient for standard PATH=^X:\^^ (^=nul byte) */
-#define DEF_PATH    "A:\\"      /* default value for path */
-
-static char default_env[ENV_SIZE];  /* default environment area */
 
 /*==== External declarations ==============================================*/
 
@@ -99,8 +88,7 @@ extern UBYTE osxhbootdelay;         /* defined in OSXH header in startup.S */
 /* used by kprintf() */
 WORD boot_status;               /* see kprint.h for bit flags */
 
-/* Boot flags */
-UBYTE bootflags;
+static void display_startup_msg(void);
 
 /* Non-Atari hardware vectors */
 #if !CONF_WITH_MFP
@@ -488,24 +476,11 @@ static void bios_init(void)
     nls_set_lang(get_lang_name());
 #endif
 
-    /* Set start of user interface.
-     * No need to check if os_header.os_magic->gm_magic == GEM_MUPB_MAGIC,
-     * as this is always true. */
-    exec_os = os_header.os_magic->gm_init;
-
-    KDEBUG(("osinit_before_xmaddalt()\n"));
-    osinit_before_xmaddalt();   /* initialize BDOS (part 1) */
-    KDEBUG(("after osinit_before_xmaddalt()\n"));
-
 #if CONF_WITH_ALT_RAM
-    /* Add Alt-RAM to BDOS pool */
+    /* Detect Alt-RAM */
     KDEBUG(("altram_init()\n"));
     altram_init();
 #endif
-
-    KDEBUG(("osinit_after_xmaddalt()\n"));
-    osinit_after_xmaddalt();    /* initialize BDOS (part 2) */
-    KDEBUG(("after osinit_after_xmaddalt()\n"));
     boot_status |= DOS_AVAILABLE;   /* track progress */
 
     /* Enable VBL processing */
@@ -535,9 +510,10 @@ static void bios_init(void)
     KDEBUG(("bios_init() end\n"));
 }
 
+
 #if DETECT_NATIVE_FEATURES
 
-static void bootstrap(void)
+void natfeat_bootstrap(const char *env)
 {
     /* start the kernel provided by the emulator */
     PD *pd;
@@ -549,7 +525,7 @@ static void bootstrap(void)
     nf_getbootstrap_args(args, sizeof(args));
 
     /* allocate space */
-    pd = (PD *) Pexec(PE_BASEPAGEFLAGS, (char*)PF_STANDARD, args, default_env);
+    pd = (PD *) Pexec(PE_BASEPAGEFLAGS, (char*)PF_STANDARD, args, env);
 
     /* get the TOS executable from the emulator */
     length = nf_bootstrap(pd->p_lowtpa + sizeof(PD), pd->p_hitpa - pd->p_lowtpa);
@@ -559,7 +535,7 @@ static void bootstrap(void)
         goto err;
 
     /* relocate the loaded executable */
-    r = Pexec(PE_RELOCATE, (char *)length, (char *)pd, default_env);
+    r = Pexec(PE_RELOCATE, (char *)length, (char *)pd, env);
     if (r != (LONG)pd)
         goto err;
 
@@ -567,7 +543,7 @@ static void bootstrap(void)
     bootdev = nf_getbootdrive();
 
     /* execute the relocated process */
-    Pexec(PE_GO, "", (char *)pd, default_env);
+    Pexec(PE_GO, "", (char *)pd, env);
 
 err:
     Mfree(pd->p_env); /* Mfree() the environment */
@@ -575,118 +551,6 @@ err:
 }
 
 #endif /* DETECT_NATIVE_FEATURES */
-
-/*
- * Build the default environment string: "PATH=^X:\^^" [where ^=nul]
- */
-static void init_default_environment(void)
-{
-    char *p;
-
-    strcpy(default_env,PATH_ENV);
-    p = default_env + sizeof(PATH_ENV); /* point to first byte of path string */
-    strcpy(p,DEF_PATH);
-    *p += bootdev;                      /* fix up drive letter */
-    p += sizeof(DEF_PATH);
-    *p = '\0';                          /* terminate with double nul */
-}
-
-#if ENABLE_RESET_RESIDENT
-/*
- * run_reset_resident - run "reset-resident" code
- *
- * "Reset-resident" code is code that has been loaded into RAM prior
- * to a warm boot.  It has a special header with a magic number, it
- * is 512 bytes long (aligned on a 512-byte boundary), and it has a
- * specific checksum (calculated on a word basis).
- *
- * Note: this is an undocumented feature of TOS that exists in all
- * versions of Atari TOS.
- */
-struct rrcode {
-    long magic;
-    struct rrcode *pointer;
-    char program[502];
-    short chksumfix;
-};
-#define RR_MAGIC    0x12123456L
-#define RR_CHKSUM   0x5678
-
-static void run_reset_resident(void)
-{
-    const struct rrcode *p = (const struct rrcode *)phystop;
-
-    for (--p; p > (struct rrcode *)&etv_timer; p--)
-    {
-        if (p->magic != RR_MAGIC)
-            continue;
-        if (p->pointer != p)
-            continue;
-        if (compute_cksum((const UWORD *)p) != RR_CHKSUM)
-            continue;
-        regsafe_call(p->program);
-    }
-}
-#endif
-
-/*
- * autoexec - run programs in auto folder
- *
- * Skip this if user holds the Control key down.
- *
- * Note that GEMDOS already created a default basepage so it is safe
- * to use GEMDOS calls here!
- */
-
-static void run_auto_program(const char* filename)
-{
-    char path[30];
-
-    strcpy(path, "\\AUTO\\");
-    strcat(path, filename);
-
-    KDEBUG(("Loading %s ...\n", path));
-    Pexec(PE_LOADGO, path, "", NULL);
-    KDEBUG(("[OK]\n"));
-}
-
-static void autoexec(void)
-{
-    DTA dta;
-    WORD err;
-
-    /* check if the user does not want to run AUTO programs */
-    if (bootflags & BOOTFLAG_SKIP_AUTO_ACC)
-        return;
-
-#if DETECT_NATIVE_FEATURES
-    bootstrap();                        /* try to boot the new OS kernel directly */
-#endif
-
-    if(!blkdev_avail(bootdev))          /* check, if bootdev available */
-        return;
-
-    Fsetdta(&dta);
-    err = Fsfirst("\\AUTO\\*.PRG", 7);
-    while(err == 0) {
-#ifdef TARGET_PRG
-        if (!strncmp(dta.d_fname, "EMUTOS", 6))
-        {
-            KDEBUG(("Skipping %s from AUTO folder\n", dta.d_fname));
-        }
-        else
-#endif
-        {
-            run_auto_program(dta.d_fname);
-
-            /* Setdta. BetaDOS corrupted the AUTO load if the Setdta
-             * not repeated here */
-            Fsetdta(&dta);
-        }
-
-        err = Fsnext();
-    }
-}
 
 #if CONF_WITH_SHUTDOWN
 
@@ -736,90 +600,14 @@ BOOL can_shutdown(void)
 
 void biosmain(void)
 {
-    BOOL show_initinfo;         /* TRUE if welcome screen must be displayed */
-    ULONG shiftbits;
-
     bios_init();                /* Initialize the BIOS */
 
-    /* Steem needs this to initialize its GEMDOS hard disk emulation.
-     * This may change drvbits. See Steem sources:
-     * File steem/code/emulator.cpp, function intercept_bios(). */
-    Drvmap();
+    /* Set start of user interface.
+     * No need to check if os_header.os_magic->gm_magic == GEM_MUPB_MAGIC,
+     * as this is always true. */
+    exec_os = os_header.os_magic->gm_init;
 
-    /*
-     * if it's not the first boot, we use the existing bootdev.
-     * this allows a boot device that was selected via the welcome
-     * screen to persist across warm boots.
-     */
-    if (FIRST_BOOT)
-        bootdev = blkdev_avail(DEFAULT_BOOTDEV) ? DEFAULT_BOOTDEV : FLOPPY_BOOTDEV;
-
-#if INITINFO_DURATION == 0
-    show_initinfo = FALSE;
-#elif ALWAYS_SHOW_INITINFO
-    show_initinfo = TRUE;
-#else
-    show_initinfo = FIRST_BOOT;
-#endif
-
-    if (show_initinfo)
-        bootdev = initinfo(&shiftbits); /* show the welcome screen */
-    else
-        shiftbits = kbshift(-1);
-
-    KDEBUG(("bootdev = %d\n", bootdev));
-
-    if (shiftbits & MODE_ALT)
-        bootflags |= BOOTFLAG_SKIP_HDD_BOOT;
-
-    if (shiftbits & MODE_CTRL)
-        bootflags |= BOOTFLAG_SKIP_AUTO_ACC;
-
-    KDEBUG(("bootflags = 0x%02x\n", bootflags));
-
-    /* boot eventually from a block device (floppy or harddisk) */
-    blkdev_boot();
-
-    Dsetdrv(bootdev);           /* Set boot drive */
-    init_default_environment(); /* Build default environment string */
-
-#if ENABLE_RESET_RESIDENT
-    run_reset_resident();       /* see comments above */
-#endif
-
-#if WITH_CLI
-    if (bootflags & BOOTFLAG_EARLY_CLI) {
-        /*
-         * run an early console, passing the default environment
-         */
-        PD *pd = (PD *) Pexec(PE_BASEPAGEFLAGS, (char *)PF_STANDARD, "", default_env);
-        pd->p_tbase = (UBYTE *) coma_start;
-        pd->p_tlen = pd->p_dlen = pd->p_blen = 0;
-        Pexec(PE_GOTHENFREE, "", (char *)pd, default_env);
-    }
-#endif
-
-    autoexec();                 /* autoexec PRGs from AUTO folder */
-
-    /* clear commandline */
-
-    if(cmdload != 0) {
-        /*
-         * Pexec a program called COMMAND.PRG
-         * like Atari TOS, it inherits an empty environment
-         */
-        Pexec(PE_LOADGO, "COMMAND.PRG", "", NULL);
-    } else if (exec_os) {
-        /*
-         * start the default (ROM) shell
-         * like Atari TOS, we pass the default environment
-         */
-        PD *pd;
-        pd = (PD *) Pexec(PE_BASEPAGEFLAGS, (char *)PF_STANDARD, "", default_env);
-        pd->p_tbase = (UBYTE *) exec_os;
-        pd->p_tlen = pd->p_dlen = pd->p_blen = 0;
-        Pexec(PE_GO, "", (char *)pd, default_env);
-    }
+    bdos_bootstrap();
 
 #if CONF_WITH_SHUTDOWN
     /* try to shutdown the machine / close the emulator */
@@ -832,7 +620,6 @@ void biosmain(void)
     kcprintf(_("System halted!\n"));
     halt();
 }
-
 
 
 /**
@@ -1015,7 +802,6 @@ static LONG bios_4(WORD r_w, UBYTE *adr, WORD numb, WORD first, WORD drive, LONG
     return ret;
 }
 #endif
-
 
 
 /**
@@ -1232,3 +1018,8 @@ BOOL is_text_pointer(const void *p)
 }
 
 #endif /* CONF_WITH_EXTENDED_MOUSE */
+
+static void display_startup_msg(void)
+{
+    cprintf("EmuTOS Version %s\r\n", version);
+}

--- a/bios/biosmem.h
+++ b/bios/biosmem.h
@@ -21,6 +21,7 @@ extern UBYTE dskbuf[DSKBUF_SIZE]; /* In ST-RAM */
 
 /* Prototypes */
 void bmem_init(void);
+void bmem_register(const char *name, enum ram_type_t type, const void *start, ULONG size);
 
 /* BIOS function */
 

--- a/bios/blkdev.c
+++ b/bios/blkdev.c
@@ -219,38 +219,6 @@ static void bus_init(void)
 }
 
 /*
- * blkdev_boot - boot from device in 'bootdev'
- */
-LONG blkdev_boot(void)
-{
-    KDEBUG(("drvbits = %08lx\n",drvbits));
-
-    /*
-     * if the user decided to skip hard drive boot, we set the
-     * boot device to floppy A:
-     */
-    if (bootflags & BOOTFLAG_SKIP_HDD_BOOT)
-        bootdev = FLOPPY_BOOTDEV;
-
-    /*
-     * if the user decided to skip AUTO programs, we don't
-     * attempt to execute the bootsector
-     */
-    if (bootflags & BOOTFLAG_SKIP_AUTO_ACC)
-        return 0;
-
-#ifdef DISABLE_HD_BOOT
-    if (bootdev >= NUMFLOPPIES) /* don't attempt to boot from hard disk */
-        return 0;
-#endif
-
-    /*
-     * execute the bootsector code (if present)
-     */
-    return blkdev_hdv_boot();
-}
-
-/*
  * blkdev_hdv_boot - BIOS boot vector
  */
 static LONG blkdev_hdv_boot(void)
@@ -809,15 +777,3 @@ LONG blkdev_drvmap(void)
     return(drvbits);
 }
 
-
-
-/*
- * blkdev_avail - Check drive availability
- *
- * Returns 0, if drive not available
- */
-
-LONG blkdev_avail(WORD dev)
-{
-    return((1L << dev) & drvbits);
-}

--- a/bios/blkdev.h
+++ b/bios/blkdev.h
@@ -35,10 +35,6 @@
 
 #define CRITIC_RETRY_REQUEST 0x00010000L    /* special value returned by etv_critic */
 
-#define FLOPPY_BOOTDEV      0   /* i.e. A: */
-#define HARDDISK_BOOTDEV    2   /* i.e. C: */
-#define DEFAULT_BOOTDEV     HARDDISK_BOOTDEV
-
 /* Original FAT12 bootsector */
 struct bs {
   /*   0 */  UBYTE bra[2];
@@ -106,7 +102,6 @@ void blkdev_init(void);
 LONG blkdev_boot(void);
 LONG blkdev_getbpb(WORD dev);
 LONG blkdev_drvmap(void);
-LONG blkdev_avail(WORD dev);
 UWORD compute_cksum(const UWORD *buf);
 WORD get_shift(ULONG blocksize);
 

--- a/bios/ikbd.c
+++ b/bios/ikbd.c
@@ -1105,3 +1105,8 @@ void kbd_init(void)
 
     bioskeys();
 }
+
+ULONG kbd_default_datetime(void)
+{
+    return DEFAULT_DATETIME;
+}

--- a/bios/ikbd.h
+++ b/bios/ikbd.h
@@ -23,8 +23,6 @@
  * Private BIOS combinations are defined below.
  */
 
-#define MODE_SHIFT  (MODE_RSHIFT|MODE_LSHIFT)   /* shifted */
-
 #define HOTSWITCH_MODE (MODE_LSHIFT|MODE_ALT)
 
 extern UBYTE shifty;

--- a/bios/machine.c
+++ b/bios/machine.c
@@ -812,3 +812,8 @@ const char * machine_name(void)
     return guess_machine_name();
 #endif
 }
+
+BOOL is_first_boot(void)
+{
+    return FIRST_BOOT;
+}

--- a/bios/machine.h
+++ b/bios/machine.h
@@ -79,9 +79,6 @@ void machine_init(void);
 /* fill the cookie jar */
 void fill_cookie_jar(void);
 
-/* print the name of the machine */
-const char * machine_name(void);
-
 #define IS_STRAM_POINTER(p) ((UBYTE *)(p) < phystop)
 
 #endif /* MACHINE_H */

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -47,7 +47,7 @@
 #include "desksupp.h"
 #include "icons.h"
 #include "xbiosbind.h"
-#include "biosext.h"
+#include "../bdos/bdosstub.h"
 
 
 /*

--- a/include/biosdefs.h
+++ b/include/biosdefs.h
@@ -98,6 +98,7 @@ typedef struct _bpb BPB;
                         /* key is released, even if the Alt key is released first.   */
 #define MODE_HOME   0x20        /* Clr/Home is down        */
 #define MODE_INSERT 0x40        /* Insert is down          */
+#define MODE_SHIFT  (MODE_RSHIFT|MODE_LSHIFT)   /* shifted (convenience */
 
 /*
  * Struct returned by Kbdvbase()

--- a/include/biosext.h
+++ b/include/biosext.h
@@ -35,11 +35,11 @@ struct font_head;
 /* Bitmap of removable logical drives */
 extern LONG drvrem;
 
-/* Boot flags */
-extern UBYTE bootflags;
-#define BOOTFLAG_EARLY_CLI     0x01
-#define BOOTFLAG_SKIP_HDD_BOOT 0x02
-#define BOOTFLAG_SKIP_AUTO_ACC 0x04
+ULONG kbd_default_datetime(void);
+
+#if DETECT_NATIVE_FEATURES
+void natfeat_bootstrap(const char *env); /* from bios.c */
+#endif
 
 /* Video RAM stuff */
 #if CONF_WITH_VIDEL
@@ -60,6 +60,20 @@ void set_cache(WORD enable);
 
 /* bios allocation of ST-RAM */
 UBYTE *balloc_stram(ULONG size, BOOL top);
+
+/* Information about available ram */
+enum ram_type_t {
+	ST = 1,
+	ALT = 2,
+};
+struct memory_block_t {
+	struct memory_block_t *next;
+	enum ram_type_t type;
+	char* name;
+	void* start;
+	ULONG size;
+};
+struct memory_block_t *bget_memory_info(void);
 
 /* print a panic message both via kprintf and cprintf, then halt */
 void panic(const char *fmt, ...) PRINTF_STYLE NORETURN;
@@ -85,6 +99,12 @@ void get_pixel_size(WORD *width,WORD *height);
 int rez_changeable(void);
 WORD check_moderez(WORD moderez);
 void initialise_palette_registers(WORD rez,WORD mode);
+
+/* return machine type name (machine.c) */
+const char *machine_name(void);
+
+/* whether it's a cold start (machine.c) */
+BOOL is_first_boot(void);
 
 /* RAM-copies of the ROM-fontheaders. See bios/fntxxx.c */
 extern struct font_head fon6x6;

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,9 +4,9 @@
 #
 
 bios/bios.c
-bios/initinfo.c
 bios/kprint.c
 
+bdos/initinfo.c
 bdos/osmem.c
 
 aes/gem_rsc.c


### PR DESCRIPTION
In particular, BIOS should not depend on BDOS. This translates into the following:

1 The BIOS no longer calls Mxaddalt. Instead it registers memory blocks and the BDOS can query that (see changes in biosext.h) and do the registration itself on startup.
2 The BIOS no longer executes programs using Pexec. Instead it calls a bdos_bootstrap that initialises the BDOS, figures out boot settings then boots. Figurint out boot settings implied moving initinfo from the BIOS to the BDOS.