### PR TITLE
Adjust 040/060 cache operations to support copyback mode

### DIFF
--- a/bios/processor.S
+++ b/bios/processor.S
@@ -390,9 +390,12 @@ _instruction_cache_kludge:
  * First, the data cache is flushed to push changes into the RAM.
  * Then the instruction cache is invalidated for the specified zone.
  *
- * We're lazy here and invalidate all the cache. A real implementation
- * would invalidate only the needed pages using several cinvp ic,(a0).
- * It is not worth the trouble for EmuTOS right now.
+ * We're cautious here and invalidate all the cache. Since not all systems
+ * map all memory 1:1, being more precise would require either knowing the
+ * physical address of line(s) to be cleaned/invalidated, or performing address
+ * translation on the range.
+ * This quickly becomes more expensive than just cleaning the caches and paying
+ * the cost to repopulate them later.
  */
 
 _invalidate_instruction_cache:
@@ -419,8 +422,12 @@ ii_not30:
         jne     ii_done
 
 ii_inval:
+        // If the 040/060 MMU is enabled, or the DTTs have been configured
+        // for copyback mode, there may be dirty lines in the data cache
+        // containing instructions, so we need to flush the data cache as well
+        // as invalidating the instruction cache.
         nop
-        CINVA_IC                // invalidate the instruction cache
+        CPUSHA_BC
         nop
 ii_done:
 #endif /* CONF_WITH_ADVANCED_CPU */
@@ -444,13 +451,19 @@ _flush_data_cache:
         jra     cpushl_loop
 #else
 #if CONF_WITH_ADVANCED_CPU
-//
-// 68030 data caches are always write-through, so no action is necessary
-//
-// 68040/68060 data caches are either write-through or copyback, depending
-// on how the system is set up.  at this time, the data TTRs are set up so
-// that the cache is write-through, so no action is necessary here either.
-//
+
+        // 68020 has no data cache, 68030 data cache is always write-through,
+        // in either case no action is necessary.
+        cmpi.b  #40,_mcpu+3
+        jmi     fd_no_dirty
+
+        // 68040/68060 data caches are either write-through or copyback
+        // depending on how the DTTs / MMU are set up, so we need to push them
+        // here.
+        nop
+        CPUSHA_DC
+        nop
+fd_no_dirty:
 #endif
         rts
 #endif
@@ -482,8 +495,12 @@ ic_not30:
         jne     ic_done
 
 ic_inval:
+        // We can't simply invalidate the data cache, as there may
+        // be dirty lines resident, so we need to push those out.
+        // Note: this requires that the 060's CACR.DPI bit is not set
+        //       in order for lines to be invalidated.
         nop
-        CINVA_DC                // invalidate the data cache
+        CPUSHA_DC
         nop
 ic_done:
 #endif /* CONF_WITH_ADVANCED_CPU */
@@ -572,7 +589,14 @@ _set_cache:
         jeq     sc_exit             // no cache, do nothing
         moveq.l #0,d0               // assume disable
         tst.w   4(sp)
-        jeq     sc_cacr             // it is, go do it
+        jne     sc_enable           // no, enable
+        cmpi.b  #40,_mcpu+3         // possible dirty data in cache?
+        jmi     sc_cacr             // no, go do it
+        nop
+        CPUSHA_DC                   // 040/060: yes, clean the data cache first
+        nop
+        jra     sc_cacr             // now go do it
+sc_enable:
         move.l  cacr_enable,d0      // enabling: set processor-appropriate value
         cmpi.b  #40,_mcpu+3         // 040/060 ?
         jmi     sc_cacr             // no, just go set cacr

--- a/bios/vectors.S
+++ b/bios/vectors.S
@@ -1,3 +1,4 @@
+    rol.w  #1,d1
 /*
  * vectors.S - exception vectors
  *
@@ -879,10 +880,11 @@ pi_not30:
         cmpi.b  #60,_mcpu+3
         jne     pi_next
 
-        // on 68040 and 68060, invalidate the line holding the opcode only
+        // on 68040 and 68060, push the whole dcache and invalidate the entire icache
+        // as we have no guarantee that physical = virtual
 pi_inval:
         nop
-        CINVL_IC_A0                     // cinvl   ic,(a0)
+        CPUSHA_BC
         nop
 
 pi_next:

--- a/include/asmdefs.h
+++ b/include/asmdefs.h
@@ -59,10 +59,11 @@
 #define FSAVE_MINUS_SP      .dc.w 0xf327            /* 6888X, 68040-68060 (except 68ec040/68ec060) */
 #define FRESTORE_SP_PLUS    .dc.w 0xf35f            /* 6888X, 68040-68060 (except 68ec040/68ec060) */
 
+#define CPUSHA_DC           .dc.w 0xf478            /* 68040-68060 */
+#define CPUSHA_BC           .dc.w 0xf4f8            /* 68040-68060 */
 #define CINVA_DC            .dc.w 0xf458            /* 68040-68060 */
 #define CINVA_IC            .dc.w 0xf498            /* 68040-68060 */
 #define CINVA_BC            .dc.w 0xf4d8            /* 68040-68060 */
-#define CINVL_IC_A0         .dc.w 0xf488            /* 68040-68060 */
 
 #define ADDIWL_0_A0         .dc.l 0x06d00000        /* 68080 */
 


### PR DESCRIPTION
These changes attempt to address the possibility of there being dirty lines in the data cache on 040/060 CPUs. These lines may be the result of copyback mode being set in the DTT registers, or pagetable entries with copyback mode selected.

Whilst these are not the default, ports may be willing to accept the DMA-related tradeoffs in return for the significant performance boost that copyback can give.

Note that these changes require that the 060 CACR.DPI bit be set to zero; this is the default.

Addresses #47 