### PR TITLE
Add PAL mode boot option

### DIFF
--- a/bios/initinfo.c
+++ b/bios/initinfo.c
@@ -27,6 +27,7 @@
 #include "blkdev.h"     /* for BLKDEVNUM */
 #include "font.h"
 #include "tosvars.h"
+#include "screen.h"
 #include "machine.h"
 #include "processor.h"
 #include "xbiosbind.h"
@@ -44,6 +45,7 @@
 
 #if FULL_INITINFO
 
+#define TAB_ASCII   0x09
 #define ESC_ASCII   0x1b
 #define DEL_ASCII   0x7f
 
@@ -358,7 +360,11 @@ WORD initinfo(ULONG *pshiftbits)
 #if WITH_CLI
     display_message(_("Press <Esc> to run an early console"));
 #endif
-    cprintf("\r\n");
+#if CONF_WITH_ATARI_VIDEO
+    if (screen_is_pal()) {
+        display_message(_("Press <Tab> to switch PAL mode"));
+    }
+#endif /* CONF_WITH_ATARI_VIDEO */
 
     /* centre 'hold shift' message in all languages */
     display_inverse(_("Hold <Shift> to pause this screen"),0);
@@ -421,6 +427,12 @@ WORD initinfo(ULONG *pshiftbits)
                 /* eat spurious Delete key press */
                 continue;
             } else
+#if CONF_WITH_ATARI_VIDEO
+            if (screen_is_pal() && c == TAB_ASCII) {
+                /* <Tab>: toggle PAL mode */
+                *(volatile UBYTE *) SYNCMODE ^= 0x02;
+            } else
+#endif /* CONF_WITH_ATARI_VIDEO */
 #if WITH_CLI
             if (c == ESC_ASCII) {
                 bootflags |= BOOTFLAG_EARLY_CLI;

--- a/bios/screen.c
+++ b/bios/screen.c
@@ -127,6 +127,30 @@ static WORD shifter_get_monitor_type(void)
         return MON_MONO;
 }
 
+int screen_is_pal(void)
+{
+#if CONF_WITH_VIDEL
+    if (has_videl)
+    {
+        /* Falcon */
+        return 0;
+    }
+    else
+#endif
+    if (HAS_TT_SHIFTER)
+    {
+        /* TT */
+        return 0;
+    }
+    /* Atari ST/STe */
+    return 1;
+}
+
+void screen_toggle_pal(void)
+{
+    *(volatile UBYTE *) SYNCMODE ^= 0x02;
+}
+
 #endif /* CONF_WITH_ATARI_VIDEO */
 
 #if CONF_WITH_TT_SHIFTER

--- a/bios/screen.h
+++ b/bios/screen.h
@@ -87,6 +87,9 @@ WORD esetsmear(WORD mode);
 #define TTRGB_LTYELLOW  0x0ff9
 #define TTRGB_WHITE     0x0fff
 
+int screen_is_pal(void);
+void screen_toggle_pal(void);
+
 #endif /* CONF_WITH_ATARI_VIDEO */
 
 /* set screen address, mode, ... */

--- a/po/fr.po
+++ b/po/fr.po
@@ -76,6 +76,10 @@ msgstr "Tapez <Esc> pour lancer la console"
 msgid "Hold <Shift> to pause this screen"
 msgstr "<Shift> pour maintenir cet écran"
 
+#: bios/initinfo.c
+msgid "Press <Tab> to switch PAL mode"
+msgstr "<Tab> pour changer la fréquence PAL"
+
 #: bios/kprint.c
 msgid ""
 "\n"


### PR DESCRIPTION
Certain screens only works properly with certain PAL mode and not necessarilly the default (eg. default is 50Hz but the screen only works correctly in 60Hz).
Add a cold boot screen option to switch PAL mode.