### PR TITLE
Support DESKTOP.INF and NEWDESK.INF as fallback when EMUDESK.INF is not found

### DIFF
--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -101,6 +101,13 @@ void gem_main(void);            /* called only from gemstart.S */
 
 #define WAIT_TIMEOUT 500                /* see wait_for_accs() */
 
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+/* use last byte of infbuf to mark DESKTOP.INF */
+#define DESKTOP_INF()   (infbuf[INF_SIZE]!=0)
+#else
+#define DESKTOP_INF()   (0)
+#endif
+
 typedef struct {                     /* used by count_accs()/ldaccs() */
     LONG addr;                          /* DA load address */
     char name[LEN_ZFNAME];              /* DA file name */
@@ -359,13 +366,32 @@ static void process_inf1(void)
             continue;
         switch(*pcurr++) {
         case 'E':               /* desktop environment, e.g. #E 3A 11 FF 02 */
-            pcurr += 6;                 /* skip over non-video preferences */
+
+            if (!DESKTOP_INF())
+                pcurr += 6;             /* emudesk.inf skip over non-video preferences */
+
             if (*pcurr == '\r')         /* no video info saved */
                 break;
 
             pcurr = scan_2(pcurr, &env1);
             pcurr = scan_2(pcurr, &env2);
             mode = MAKE_UWORD(env1, env2);
+
+            if (DESKTOP_INF())                     /* desktop.inf */
+            {
+                /* convert to emudesk ST video mode */
+                switch (mode & 0x000F)
+                {
+                    default:
+                    case 1: mode = 0xFF00 | ST_LOW; break;
+                    case 2: mode = 0xFF00 | ST_MEDIUM; break;
+                    case 3: mode = 0xFF00 | ST_HIGH; break;
+                    case 4: mode = 0xFF00 | TT_LOW; break;
+                    case 5: mode = 0xFF00 | TT_MEDIUM; break;
+                    case 6: mode = 0xFF00 | TT_HIGH; break;
+                }
+            }
+
             mode = check_moderez(mode);
             if (mode == 0)              /* no change required */
                 break;
@@ -422,17 +448,21 @@ static BOOL process_inf2(BOOL *isauto)
         {                           /* desktop environment          */
             pcurr += 2;
             pcurr = scan_2(pcurr, &env);
-            ev_dclick(env & 0x07, TRUE);
+            if (!DESKTOP_INF())     /* desktop.inf does not store dclick here */
+                ev_dclick(env & 0x07, TRUE);
             pcurr = scan_2(pcurr, &env);    /* get desired blitter state */
 #if CONF_WITH_BLITTER
             if (has_blitter)
                 Blitmode((env&0x80)?1:0);
 #endif
 #if CONF_WITH_CACHE_CONTROL
-            pcurr = scan_2(pcurr, &env);    /* skip over video bytes if present */
-            pcurr = scan_2(pcurr, &env);
-            scan_2(pcurr, &env);            /* get desired cache state */
-            set_cache((env&0x08)?0:1);
+            if (!DESKTOP_INF())                 /* emudesk.inf */
+            {
+                pcurr = scan_2(pcurr, &env);    /* skip over video bytes if present */
+                pcurr = scan_2(pcurr, &env);
+                scan_2(pcurr, &env);            /* get desired cache state */
+                set_cache((env&0x08)?0:1);
+            }
 #endif
         }
         else if (tmp == 'Z')        /* something like "#Z 01 C:\THING.APP@" */
@@ -768,9 +798,37 @@ void gem_main(void)
     else
         n = readfile(INF_FILE_NAME, INF_SIZE, infbuf);
 
+#if !CONF_WITH_DESKTOP_INF_FALLBACK
     if (n < 0L)
         n = 0L;
-    infbuf[n] = '\0';           /* terminate input data */
+    infbuf[n] = '\0';               /* terminate input data */
+#else
+    if (n >= 0L)
+    {
+        infbuf[n] = '\0';
+        infbuf[INF_SIZE] = '\0';    /* 0 marks as emudesk format */
+    }
+    else                            /* not found, try desktop.inf, newdesk.inf */
+    {
+        n = readfile(INF_FILE_ALT1, INF_SIZE-1, infbuf);
+        if (n >= 0L)
+        {
+            infbuf[n] = '\0';
+            infbuf[INF_SIZE] = 1;   /* 1 marks as desktop.inf */
+        }
+        else
+        {
+            n = readfile(INF_FILE_ALT2, INF_SIZE-1, infbuf);
+            if (n >= 0L)
+            {
+                infbuf[n] = '\0';
+                infbuf[INF_SIZE] = 2;   /* 2 marks as newdesk.inf */
+            }
+            else
+                infbuf[0] = '\0';   /* empty file */
+        }
+    }
+#endif
 
     if (!gl_changerez)          /* can't be here because of rez change,       */
         process_inf1();         /*  so see if .inf says we need to change rez */

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -808,21 +808,21 @@ void gem_main(void)
         infbuf[n] = '\0';
         infbuf[INF_SIZE] = '\0';    /* 0 marks as emudesk format */
     }
-    else                            /* not found, try desktop.inf, newdesk.inf */
+    else                            /* not found, try newdesk.inf, desktop.inf */
     {
-        n = readfile(INF_FILE_ALT1, INF_SIZE-1, infbuf);
+        n = readfile(INF_FILE_ALT2, INF_SIZE-1, infbuf);
         if (n >= 0L)
         {
             infbuf[n] = '\0';
-            infbuf[INF_SIZE] = 1;   /* 1 marks as desktop.inf */
+            infbuf[INF_SIZE] = 2;   /* 2 marks as newdesk.inf */
         }
         else
         {
-            n = readfile(INF_FILE_ALT2, INF_SIZE-1, infbuf);
+            n = readfile(INF_FILE_ALT1, INF_SIZE-1, infbuf);
             if (n >= 0L)
             {
                 infbuf[n] = '\0';
-                infbuf[INF_SIZE] = 2;   /* 2 marks as newdesk.inf */
+                infbuf[INF_SIZE] = 1;   /* 1 marks as desktop.inf */
             }
             else
                 infbuf[0] = '\0';   /* empty file */

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -102,8 +102,8 @@ void gem_main(void);            /* called only from gemstart.S */
 #define WAIT_TIMEOUT 500                /* see wait_for_accs() */
 
 #if CONF_WITH_DESKTOP_INF_FALLBACK
-/* use last byte of infbuf to mark DESKTOP.INF */
-#define DESKTOP_INF()   (infbuf[INF_SIZE]!=0)
+extern WORD     inf_rev_level;              /* from deskapp.c */
+#define DESKTOP_INF()   (inf_rev_level<0)
 #else
 #define DESKTOP_INF()   (0)
 #endif
@@ -377,7 +377,7 @@ static void process_inf1(void)
             pcurr = scan_2(pcurr, &env2);
             mode = MAKE_UWORD(env1, env2);
 
-            if (DESKTOP_INF())                     /* desktop.inf */
+            if (DESKTOP_INF())          /* desktop.inf */
             {
                 /* convert to emudesk ST video mode */
                 switch (mode & 0x000F)
@@ -803,26 +803,26 @@ void gem_main(void)
         n = 0L;
     infbuf[n] = '\0';               /* terminate input data */
 #else
+    inf_rev_level = 0;
     if (n >= 0L)
     {
         infbuf[n] = '\0';
-        infbuf[INF_SIZE] = '\0';    /* 0 marks as emudesk format */
     }
     else                            /* not found, try newdesk.inf, desktop.inf */
     {
-        n = readfile(INF_FILE_ALT2, INF_SIZE-1, infbuf);
-        if (n >= 0L)
+        n = readfile(INF_FILE_ALT2, INF_SIZE, infbuf);
+        if (n >= 0L)                /* newdesk.inf */
         {
             infbuf[n] = '\0';
-            infbuf[INF_SIZE] = 2;   /* 2 marks as newdesk.inf */
+            inf_rev_level = -1;
         }
         else
         {
-            n = readfile(INF_FILE_ALT1, INF_SIZE-1, infbuf);
-            if (n >= 0L)
+            n = readfile(INF_FILE_ALT1, INF_SIZE, infbuf);
+            if (n >= 0L)            /* desktop.inf */
             {
                 infbuf[n] = '\0';
-                infbuf[INF_SIZE] = 1;   /* 1 marks as desktop.inf */
+                inf_rev_level = -1;
             }
             else
                 infbuf[0] = '\0';   /* empty file */

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -101,13 +101,6 @@ void gem_main(void);            /* called only from gemstart.S */
 
 #define WAIT_TIMEOUT 500                /* see wait_for_accs() */
 
-#if CONF_WITH_DESKTOP_INF_FALLBACK
-extern WORD     inf_rev_level;              /* from deskapp.c */
-#define DESKTOP_INF()   (inf_rev_level<0)
-#else
-#define DESKTOP_INF()   (0)
-#endif
-
 typedef struct {                     /* used by count_accs()/ldaccs() */
     LONG addr;                          /* DA load address */
     char name[LEN_ZFNAME];              /* DA file name */
@@ -119,6 +112,13 @@ static char     infbuf[INF_SIZE+1];     /* used to read part of EMUDESK.INF */
 #if CONF_WITH_BACKGROUNDS
 static BOOL     bgfound;                /* 'Q' line found in EMUDESK.INF? */
 static WORD     bg[3];                  /* desktop backgrounds (1, 2, >2 planes) */
+#endif
+
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+static BOOL     desktop_inf;            /* indicates legacy INF format */
+#define DESKTOP_INF()   (desktop_inf)
+#else
+#define DESKTOP_INF()   (0)
 #endif
 
 /* Some global variables: */
@@ -803,7 +803,7 @@ void gem_main(void)
         n = 0L;
     infbuf[n] = '\0';               /* terminate input data */
 #else
-    inf_rev_level = 0;
+    desktop_inf = FALSE;
     if (n >= 0L)
     {
         infbuf[n] = '\0';
@@ -814,7 +814,7 @@ void gem_main(void)
         if (n >= 0L)                /* newdesk.inf */
         {
             infbuf[n] = '\0';
-            inf_rev_level = -1;
+            desktop_inf = TRUE;
         }
         else
         {
@@ -822,7 +822,7 @@ void gem_main(void)
             if (n >= 0L)            /* desktop.inf */
             {
                 infbuf[n] = '\0';
-                inf_rev_level = -1;
+                desktop_inf = TRUE;
             }
             else
                 infbuf[0] = '\0';   /* empty file */

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -420,13 +420,7 @@ static char *app_parse(char *pcurr, ANODE *pa)
 #endif
 
     pcurr = scan_2(pcurr, &pa->a_aicon);
-    if (pa->a_aicon >= G.g_numiblks)
-        pa->a_aicon = IG_APPL;
     pcurr = scan_2(pcurr, &pa->a_dicon);
-    if (pa->a_dicon >= G.g_numiblks)
-        pa->a_dicon = IG_DOCU;
-    pcurr++;
-
 #if CONF_WITH_DESKTOP_INF_FALLBACK
     /* convert icon numbers in DESKTOP.INF */
     if (inf_rev_level < 0)
@@ -434,8 +428,13 @@ static char *app_parse(char *pcurr, ANODE *pa)
         pa->a_aicon = desktop_inf_icon(pa->a_aicon);
         pa->a_dicon = desktop_inf_icon(pa->a_dicon);
     }
-    else
 #endif
+    if (pa->a_aicon >= G.g_numiblks)
+        pa->a_aicon = IG_APPL;
+    if (pa->a_dicon >= G.g_numiblks)
+        pa->a_dicon = IG_DOCU;
+    pcurr++;
+
     /* convert icon numbers in EMUDESK.INF revision 0 */
     if (inf_rev_level == 0)
     {

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -781,15 +781,6 @@ static void read_inf_file(char *infbuf)
         /* rev -1 prefix indicates desktop.inf format */
         strcpy(infbuf,DESKTOP_INF_PREFIX);
 
-        strcpy(inf_file_name, INF_FILE_ALT1);
-        inf_file_name[0] += G.g_stdrv;
-        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
-        if (ret >= 0)
-        {
-            infbuf[ret+DIP_LEN] = '\0';
-            return;           /* desktop.inf */
-        }
-
         strcpy(inf_file_name, INF_FILE_ALT2);
         inf_file_name[0] += G.g_stdrv;
         ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
@@ -797,6 +788,15 @@ static void read_inf_file(char *infbuf)
         {
             infbuf[ret+DIP_LEN] = '\0';
             return;           /* newdesk.inf */
+        }
+
+        strcpy(inf_file_name, INF_FILE_ALT1);
+        inf_file_name[0] += G.g_stdrv;
+        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
+        if (ret >= 0)
+        {
+            infbuf[ret+DIP_LEN] = '\0';
+            return;           /* desktop.inf */
         }
     }
     infbuf[0] = '\0';         /* no file */

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -289,6 +289,59 @@ char *scan_str(char *pcurr, char **ppstr)
 }
 
 
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+/*
+ * Convert a DESKTOP.INF icon index to EMUDESK.INF
+ */
+static UWORD desktop_inf_icon(WORD i)
+{
+    static const UWORD DESKTOP_INF_ICON_CONVERT[12] = {
+        IG_FLOPPY,
+        IG_FOLDER,
+        IG_TRASH,
+        IG_APPL,
+        IG_DOCU,
+        /* TOS 2.xx */
+        IG_PRINT,
+        IG_PRINT, /* laser printer */
+        IG_REMOV, /* CD ROM */
+        IG_REMOV, /* cartridge */
+        IG_FLOPPY,
+        IG_DOCU, /* TOS document */
+        IG_HARD,
+    };
+    if (i < 0)
+        return i;
+    if (i >= 12)
+        return IG_DOCU;
+    return DESKTOP_INF_ICON_CONVERT[i];
+}
+
+
+/*
+ * If the next token is a 3 digit hex number, skip over it,
+ * otherwise return the starting position.
+ */
+static char* scan_skip3(char *pcurr)
+{
+    int i;
+    char* pskip = pcurr;
+
+    while(*pskip == ' ')
+        pskip++;
+    for (i = 0; i < 3; i++)
+    {
+        if ((*pskip < '0' || *pskip > '9') && (*pskip < 'A' || *pskip > 'F'))
+            return pcurr;   /* desktop.inf assumed */
+        pskip++;
+    }
+    if (*pskip == ' ')
+        return pskip;       /* newdesk.inf 000 skipped */
+    return pcurr;           /* desktop.inf assumed */
+}
+#endif /* CONF_WITH_DESKTOP_INF_FALLBACK */
+
+
 /*
  *  Parse a single line from the EMUDESK.INF file
  */
@@ -356,6 +409,16 @@ static char *app_parse(char *pcurr, ANODE *pa)
         pcurr = scan_2(pcurr, &pa->a_yspot);
     }
 
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+    if (inf_rev_level < 0 && !(pa->a_flags & AF_ISDESK))
+    {
+        /* newdesk.inf contains a 3 digit hex entry here,
+         * which was used for keyboard shortcut assignment
+         * in fields DFGINPY. */
+        pcurr = scan_skip3(pcurr);
+    }
+#endif
+
     pcurr = scan_2(pcurr, &pa->a_aicon);
     if (pa->a_aicon >= G.g_numiblks)
         pa->a_aicon = IG_APPL;
@@ -364,9 +427,16 @@ static char *app_parse(char *pcurr, ANODE *pa)
         pa->a_dicon = IG_DOCU;
     pcurr++;
 
-    /*
-     * convert icon numbers in EMUDESK.INF revision 0
-     */
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+    /* convert icon numbers in DESKTOP.INF */
+    if (inf_rev_level < 0)
+    {
+        pa->a_aicon = desktop_inf_icon(pa->a_aicon);
+        pa->a_dicon = desktop_inf_icon(pa->a_dicon);
+    }
+    else
+#endif
+    /* convert icon numbers in EMUDESK.INF revision 0 */
     if (inf_rev_level == 0)
     {
         if (pa->a_aicon == IG_APPL_REV0)
@@ -382,6 +452,10 @@ static char *app_parse(char *pcurr, ANODE *pa)
     }
     pcurr = scan_str(pcurr, &pa->a_pappl);
     pcurr = scan_str(pcurr, &pa->a_pdata);
+
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+    if (inf_rev_level >= 0)   /* -1 is desktop.inf */
+#endif
     if (*pcurr == ' ')          /* new format */
     {
         pcurr++;
@@ -414,6 +488,9 @@ static char *app_parse(char *pcurr, ANODE *pa)
         {
         case AT_ISFILE:
         case AT_ISFOLD:
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+            if (inf_rev_level >= 0)   /* -1 is desktop.inf */
+#endif
             if (inf_rev_level < 2)
             {
                 temp = pa->a_pappl;
@@ -686,9 +763,45 @@ static void read_inf_file(char *infbuf)
     inf_file_name[0] += G.g_stdrv;      /* Adjust drive letter  */
 
     ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-1, infbuf);
+
+#if !CONF_WITH_DESKTOP_INF_FALLBACK
     if (ret < 0L)
         ret = 0L;
     infbuf[ret] = '\0';
+#else
+#define DESKTOP_INF_PREFIX       "#R FF\r\n"
+#define DIP_LEN                  7
+    if (ret >= 0L)
+    {
+        infbuf[ret] = '\0';
+        return;               /* emudesk.inf */
+    }
+    else                      /* not found, try ST desktop.inf instead */
+    {
+        /* rev -1 prefix indicates desktop.inf format */
+        strcpy(infbuf,DESKTOP_INF_PREFIX);
+
+        strcpy(inf_file_name, INF_FILE_ALT1);
+        inf_file_name[0] += G.g_stdrv;
+        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
+        if (ret >= 0)
+        {
+            infbuf[ret+DIP_LEN] = '\0';
+            return;           /* desktop.inf */
+        }
+
+        strcpy(inf_file_name, INF_FILE_ALT2);
+        inf_file_name[0] += G.g_stdrv;
+        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
+        if (ret >= 0)
+        {
+            infbuf[ret+DIP_LEN] = '\0';
+            return;           /* newdesk.inf */
+        }
+    }
+    infbuf[0] = '\0';         /* no file */
+#undef DIP_LEN
+#endif
 }
 
 
@@ -829,6 +942,10 @@ void app_start(void)
     G.g_patcol[2].window = INF_Q6_DEFAULT;
 #endif
 
+    /* make sure there isn't old data in our allocated buffer */
+    buf[0] = '\0';
+    buf[CPDATA_LEN] = '\0';
+
     shel_get(buf, SIZE_SHELBUF);
     inf_data = buf + CPDATA_LEN;
     if (!(bootflags & BOOTFLAG_SKIP_AUTO_ACC)
@@ -895,12 +1012,22 @@ void app_start(void)
                 pcurr = scan_2(pcurr, &pws->vsl_save);
 /* BugFix       */
                 pcurr = scan_2(pcurr, &pws->x_save);
-                pws->x_save *= gl_wchar;
                 pcurr = scan_2(pcurr, &pws->y_save);
-                pws->y_save *= gl_hchar;
                 pcurr = scan_2(pcurr, &pws->w_save);
-                pws->w_save *= gl_wchar;
                 pcurr = scan_2(pcurr, &pws->h_save);
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+                if (inf_rev_level < 0)
+                {
+                    /* emutos file windows have no horizontal scroll,
+                    * compensate to show the correct icon, if possible.
+                    * every 10 width adds another icon to the row. */
+                    pws->vsl_save += pws->hsl_save / (pws->w_save / 10);
+                    pws->hsl_save = 0;
+                }
+#endif
+                pws->x_save *= gl_wchar;
+                pws->y_save *= gl_hchar;
+                pws->w_save *= gl_wchar;
                 pws->h_save *= gl_hchar;
 /* */
                 pcurr += 4;             /* skip no-longer-used field */
@@ -914,6 +1041,10 @@ void app_start(void)
         case 'E':                       /* Environment */
             pcurr++;
             pcurr = scan_2(pcurr, &envr);
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+            if (inf_rev_level < 0)
+                envr &= 0xF8; /* low 3 bits used differently by emudesk (double click), default 0 */
+#endif
             cnxsave->cs_view = (envr & INF_E1_VIEWTEXT) ? V_TEXT : V_ICON;
             cnxsave->cs_sort = ( (envr & INF_E1_SORTMASK) >> 5);
             cnxsave->cs_confdel = ( (envr & INF_E1_CONFDEL) != 0);
@@ -921,6 +1052,10 @@ void app_start(void)
             cnxsave->cs_dblclick = envr & INF_E1_DCMASK;
 
             pcurr = scan_2(pcurr, &envr);
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+            if (inf_rev_level < 0) /* only blitter setting bit is compatible */
+                envr = (INF_E2_DEFAULT & ~INF_E2_BLITTER) | (envr & INF_E2_BLITTER);
+#endif
             cnxsave->cs_blitter = ( (envr & INF_E2_BLITTER) != 0);
             cnxsave->cs_confovwr = ( (envr & INF_E2_ALLOWOVW) == 0);
             if (envr & INF_E2_IDTDATE)
@@ -936,6 +1071,10 @@ void app_start(void)
             pcurr = scan_2(pcurr, &dummy);
 
             pcurr = scan_2(pcurr, &envr);
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+            if (inf_rev_level < 0)
+                envr = INF_E5_DEFAULT; /* no compatible data */
+#endif
             if (envr & INF_E5_NOSORT)
                 cnxsave->cs_sort = CS_NOSORT;
 #if CONF_WITH_DESKTOP_CONFIG
@@ -965,6 +1104,10 @@ void app_start(void)
          * versions of the ROM to _load_ menu item shortcuts.
          */
         case 'K':                       /* menu item shortcuts */
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+            if (inf_rev_level < 0)
+                break;                  /* not compatible with emudesk */
+#endif
             pcurr++;
             for (i = 0; i < NUM_SHORTCUTS; i++)
             {
@@ -972,7 +1115,9 @@ void app_start(void)
                 pcurr = scan_2(pcurr, &temp);
                 menu_shortcuts[i] = (UBYTE)temp;
             }
-        break;
+            break;
+        default:                        /* ignore unknown line types */
+            break;
         }
     }
 

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -1011,7 +1011,7 @@ void app_start(void)
                 pcurr = scan_2(pcurr, &pws->w_save);
                 pcurr = scan_2(pcurr, &pws->h_save);
 #if CONF_WITH_DESKTOP_INF_FALLBACK
-                if (inf_rev_level < 0)
+                if (inf_rev_level < 0 && pws->w_save >= 10)
                 {
                     /* emutos file windows have no horizontal scroll,
                     * compensate to show the correct icon, if possible.

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -322,10 +322,10 @@ static UWORD desktop_inf_icon(WORD i)
  * If the next token is a 3 digit hex number, skip over it,
  * otherwise return the starting position.
  */
-static char* scan_skip3(char *pcurr)
+static char *scan_skip3(char *pcurr)
 {
     int i;
-    char* pskip = pcurr;
+    char *pskip = pcurr;
 
     while(*pskip == ' ')
         pskip++;
@@ -409,16 +409,6 @@ static char *app_parse(char *pcurr, ANODE *pa)
         pcurr = scan_2(pcurr, &pa->a_yspot);
     }
 
-#if CONF_WITH_DESKTOP_INF_FALLBACK
-    if (inf_rev_level < 0 && !(pa->a_flags & AF_ISDESK))
-    {
-        /* newdesk.inf contains a 3 digit hex entry here,
-         * which was used for keyboard shortcut assignment
-         * in fields DFGINPY. */
-        pcurr = scan_skip3(pcurr);
-    }
-#endif
-
     pcurr = scan_2(pcurr, &pa->a_aicon);
     pcurr = scan_2(pcurr, &pa->a_dicon);
 #if CONF_WITH_DESKTOP_INF_FALLBACK
@@ -443,6 +433,16 @@ static char *app_parse(char *pcurr, ANODE *pa)
         if (pa->a_dicon == IG_DOCU_REV0)
             pa->a_dicon = IG_DOCU;
     }
+
+#if CONF_WITH_DESKTOP_INF_FALLBACK
+    if ((inf_rev_level < 0) && !(pa->a_flags & AF_ISDESK))
+    {
+        /* newdesk.inf contains a 3 digit hex entry here,
+         * which was used for keyboard shortcut assignment
+         * in fields DFGINPY. */
+        pcurr = scan_skip3(pcurr);
+    }
+#endif
 
     if (pa->a_flags & AF_ISDESK)
     {

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -141,7 +141,7 @@
 #define MAX_SIZE_INF_LINE   (MAXPATHLEN+100)    /* conservative */
 
 
-static WORD     inf_rev_level;  /* revision level of current EMUDESK.INF */
+GLOBAL WORD     inf_rev_level;  /* revision level of current EMUDESK.INF */
 
 static char     *atextptr;      /* current pointer within ANODE text buffer */
 

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -768,8 +768,6 @@ static void read_inf_file(char *infbuf)
         ret = 0L;
     infbuf[ret] = '\0';
 #else
-#define DESKTOP_INF_PREFIX       "#R FF\r\n"
-#define DIP_LEN                  7
     if (ret >= 0L)
     {
         infbuf[ret] = '\0';
@@ -777,29 +775,27 @@ static void read_inf_file(char *infbuf)
     }
     else                      /* not found, try ST desktop.inf instead */
     {
-        /* rev -1 prefix indicates desktop.inf format */
-        strcpy(infbuf,DESKTOP_INF_PREFIX);
-
         strcpy(inf_file_name, INF_FILE_ALT2);
         inf_file_name[0] += G.g_stdrv;
-        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
+        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-1, infbuf);
         if (ret >= 0)
         {
-            infbuf[ret+DIP_LEN] = '\0';
+            infbuf[ret] = '\0';
+            inf_rev_level = -1;
             return;           /* newdesk.inf */
         }
 
         strcpy(inf_file_name, INF_FILE_ALT1);
         inf_file_name[0] += G.g_stdrv;
-        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-(1+DIP_LEN), infbuf+DIP_LEN);
+        ret = dos_load_file(inf_file_name, SIZE_SHELBUF-CPDATA_LEN-1, infbuf);
         if (ret >= 0)
         {
-            infbuf[ret+DIP_LEN] = '\0';
+            infbuf[ret] = '\0';
+            inf_rev_level = -1;
             return;           /* desktop.inf */
         }
     }
     infbuf[0] = '\0';         /* no file */
-#undef DIP_LEN
 #endif
 }
 
@@ -944,6 +940,7 @@ void app_start(void)
     /* make sure there isn't old data in our allocated buffer */
     buf[0] = '\0';
     buf[CPDATA_LEN] = '\0';
+    inf_rev_level = 0;
 
     shel_get(buf, SIZE_SHELBUF);
     inf_data = buf + CPDATA_LEN;
@@ -956,7 +953,6 @@ void app_start(void)
         build_inf(inf_data, xcnt, ycnt);
 
     wincnt = 0;
-    inf_rev_level = 0;
     pcurr = inf_data;
 
     while(*pcurr)

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -141,7 +141,7 @@
 #define MAX_SIZE_INF_LINE   (MAXPATHLEN+100)    /* conservative */
 
 
-GLOBAL WORD     inf_rev_level;  /* revision level of current EMUDESK.INF */
+static WORD     inf_rev_level;  /* revision level of current EMUDESK.INF */
 
 static char     *atextptr;      /* current pointer within ANODE text buffer */
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -14,6 +14,5 @@ AES
 
 DESK
 - Add a dialog for configuring the NVRAM (keyboard, languages, ...)
-- Support for loading DESKTOP.INF?NEWDESK.INF? (needs remapping of the icon indexes)
 
 CLI

--- a/include/config.h
+++ b/include/config.h
@@ -1869,7 +1869,7 @@
 
 /*
  * Set CONF_WITH_DESKTOP_INF_FALLBACK to 1 to support a fallback to
- * ST TOS' DESKTOP.INF and STE+ TOS' NEWDESK.INF when EMUDESK.INF does not exist.
+ * STE+ TOS' NEWDESK.INF and ST TOS' DESKTOP.INF when EMUDESK.INF does not exist.
  * (Provides better user experience with Atari ST disks made with TOS.)
  */
 #ifndef CONF_WITH_DESKTOP_INF_FALLBACK

--- a/include/config.h
+++ b/include/config.h
@@ -1867,6 +1867,19 @@
 # define CONF_WITH_WINDOW_ICONS 1
 #endif
 
+/*
+ * Set CONF_WITH_DESKTOP_INF_FALLBACK to 1 to support a fallback to
+ * ST TOS' DESKTOP.INF and STE+ TOS' NEWDESK.INF when EMUDESK.INF does not exist.
+ * (Provides better user experience with Atari ST disks made with TOS.)
+ */
+#ifndef CONF_WITH_DESKTOP_INF_FALLBACK
+# if CONF_ATARI_HARDWARE
+#  define CONF_WITH_DESKTOP_INF_FALLBACK 1
+# else
+#  define CONF_WITH_DESKTOP_INF_FALLBACK 0
+# endif
+#endif
+
 
 
 /****************************************

--- a/include/sysconf.h
+++ b/include/sysconf.h
@@ -42,6 +42,8 @@
 
 #define BLKDEVNUM   26                  /* number of block devices supported: A: ... Z: */
 #define INF_FILE_NAME "A:\\EMUDESK.INF" /* path to saved desktop file */
+#define INF_FILE_ALT1 "A:\\DESKTOP.INF" /* path to ST TOS desktop file */
+#define INF_FILE_ALT2 "A:\\NEWDESK.INF" /* path to STE TOS desktop file */
 #define INF_FILE_WILD "A:\\*.INF"       /* wildcard for desktop file */
 #define ICON_RSC_NAME "A:\\EMUICON.RSC" /* path to user icon file */
 


### PR DESCRIPTION
This is intended for better support of existing ST and STE software, especially where disks must be treated as read-only. If EMUDESK.INF is not found it will attempt to load DESKTOP.INF, then NEWDESK.INF and parse them to the extent that they are compatible.

Notably, medium (or other) resolution can be selected at boot. Desktop icons are translated to EmuTOS ones. Windows are opened, though it's not possible to make scrolled contents match identically.

Keyboard shortcuts #K are ignored (possibly they could be translated to EmuTOS actions with some effort). NEWDESK.INF icon key shortcuts are also ignored.

This does not add any ability to save either format, it is mostly intended to help old disks start up in a more friendly and immediately usable state.

I made it enabled/disabled as `CONF_WITH_DESKTOP_INF_FALLBACK` which by default I have enabled only if `CONF_ATARI_HARDWARE` is present.

**Links to test disk images below:**
* [inf_icons.zip](#issuecomment-5366666280)
* [inf_tests2.zip](#issuecomment-5387969507)